### PR TITLE
flake: update inputs (#516)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733625333,
-        "narHash": "sha256-tIML2axjm4AnlKP29upVJxzBpj4Cy4ak+PKonqQtXmc=",
+        "lastModified": 1733884434,
+        "narHash": "sha256-8GXR9kC07dyOIshAyfZhG11xfvBRSZzYghnZ2weOKJU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "430c8b054e45ea44fd2c9521a378306ada507a6c",
+        "rev": "d0483df44ddf0fd1985f564abccbe568e020ddf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/22c3f2cf41a0e70184334a958e6b124fb0ce3e01?narHash=sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY%3D' (2024-12-07)
  → 'github:NixOS/nixpkgs/a73246e2eef4c6ed172979932bc80e1404ba2d56?narHash=sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU%3D' (2024-12-09)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/4dc2fc4e62dbf62b84132fe526356fbac7b03541?narHash=sha256-FillH0qdWDt/nlO6ED7h4cmN%2BG9uXwGjwmCnHs0QVYM%3D' (2024-12-05)
  → 'github:NixOS/nixpkgs/a0f3e10d94359665dba45b71b4227b0aeb851f8e?narHash=sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk%3D' (2024-12-10)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/430c8b054e45ea44fd2c9521a378306ada507a6c?narHash=sha256-tIML2axjm4AnlKP29upVJxzBpj4Cy4ak%2BPKonqQtXmc%3D' (2024-12-08)
  → 'github:oxalica/rust-overlay/d0483df44ddf0fd1985f564abccbe568e020ddf2?narHash=sha256-8GXR9kC07dyOIshAyfZhG11xfvBRSZzYghnZ2weOKJU%3D' (2024-12-11)